### PR TITLE
コメント投稿機能の実装

### DIFF
--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -156,3 +156,115 @@
   background-color: #f8d7da;
   color: #b02a37;
 }
+
+/* コメント全体のセクション */
+.comment-section {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 20px;
+  background-color: #fafafa;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+/* タイトル */
+.comment-title {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+/* コメントフォーム */
+.comment-form {
+  margin-bottom: 30px;
+}
+
+.comment-textarea {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 14px;
+  resize: vertical;
+  font-family: inherit;
+  background-color: #fff;
+  box-sizing: border-box;
+}
+
+.comment-submit-button {
+  display: block;
+  margin: 4px auto 0;  /* 上の余白をギリギリに調整 */
+  background-color: #00b3a6;
+  color: #fff;
+  border: none;
+  padding: 8px 24px;
+  border-radius: 20px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  width: auto;
+  min-width: 120px;
+  text-align: center;
+}
+
+
+.comment-submit-button:hover {
+  background-color: #00998e;
+}
+
+/* コメント一覧 */
+.comment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* 各コメントカード */
+.comment-card {
+  background-color: #fff;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+}
+
+/* コメントメタ情報（名前と日付） */
+.comment-meta {
+  font-size: 13px;
+  color: #555;
+  margin-bottom: 8px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.comment-date {
+  color: #aaa;
+  font-size: 12px;
+}
+
+
+/* コメント本文 */
+.comment-text {
+  font-size: 14px;
+  color: #333;
+  white-space: pre-wrap;
+}
+
+/* 未ログイン時の案内 */
+.login-prompt {
+  font-size: 14px;
+  color: #666;
+  text-align: center;
+  margin-top: 10px;
+}
+
+.flash-alert {
+  background-color: #ffe0e0;
+  color: #d00;
+  padding: 10px 15px;
+  border-radius: 6px;
+  margin-bottom: 15px;
+  font-weight: bold;
+  text-align: center;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,6 +3,8 @@ class CommentsController < ApplicationController
 
   def create
     @comment = Comment.new(comment_params)
+    @post = Post.find(params[:post_id])
+    @comments = @post.comments.includes(:user).order(created_at: :asc)
 
     if @comment.save
       redirect_to post_path(@comment.post.id)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,19 @@
+class CommentsController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
+
+  def create
+    @comment = Comment.new(comment_params)
+
+    if @comment.save
+      redirect_to post_path(@comment.post.id)
+    else
+      flash.now[:alert] = "コメントの投稿に失敗しました"
+      render "posts/show", status: :unprocessable_entity
+    end
+  end
+
+  private
+  def comment_params
+    params.require(:comment).permit(:text).merge(user_id: current_user.id, post_id: params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -68,6 +68,8 @@ class PostsController < ApplicationController
   end
 
   def show
+    @comment = Comment.new
+    @comments = @post.comments.includes(:user).order(created_at: :asc)
   end
 
   def edit

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :text, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   has_one :actual_time, dependent: :destroy
   belongs_to :user
+  has_many :comments, dependent: :destroy
 
   validates :title, presence: true
   validates :task_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :nickname, presence: true
 
   has_many :posts
+  has_many :comments, dependent: :destroy
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -46,3 +46,42 @@
     </div>
   </div>
 </div>
+
+<div class="comment-section">
+  <h3 class="comment-title">コメント</h3>
+
+  <!-- コメント投稿フォーム（ログインユーザーのみ表示） -->
+  <% if flash[:alert] %>
+    <div class="flash-alert">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+
+  <% if user_signed_in? %>
+    <div class="comment-form">
+      <%= form_with(model: [@post, @comment], local: true) do |f| %>
+        <div class="form-group">
+          <%= f.text_area :text, placeholder: "コメントする", rows: 3, class: "comment-textarea" %>
+        </div>
+        <div class="form-group">
+          <%= f.submit "送信", class: "comment-submit-button" %>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="login-prompt">コメントするにはログインしてください。</p>
+  <% end %>
+
+  <!-- コメント一覧（古い順に並べる） -->
+  <div class="comment-list">
+    <% @comments.each do |comment| %>
+      <div class="comment-card">
+        <p class="comment-meta">
+          <%= link_to comment.user.nickname, user_path(comment.user), class: "comment-author" %>
+          <span class="comment-date"><%= l(comment.created_at, format: :short) %></span>
+        </p>
+        <p class="comment-text"><%= simple_format(h(comment.text)) %></p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       get  :stopwatch
       post :save_time
     end
+    resources :comments, only: [:create]
   end
   resources :users, only: [:show]
 end

--- a/db/migrate/20250327172147_create_comments.rb
+++ b/db/migrate/20250327172147_create_comments.rb
@@ -1,0 +1,10 @@
+class CreateComments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :comments do |t|
+      t.text :text,          null: false
+      t.references :post, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_27_093216) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_27_172147) do
   create_table "actual_times", charset: "utf8mb3", force: :cascade do |t|
     t.integer "actual_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "post_id", null: false
     t.index ["post_id"], name: "index_actual_times_on_post_id"
+  end
+
+  create_table "comments", charset: "utf8mb3", force: :cascade do |t|
+    t.text "text", null: false
+    t.bigint "post_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "posts", charset: "utf8mb3", force: :cascade do |t|
@@ -45,5 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_27_093216) do
   end
 
   add_foreign_key "actual_times", "posts"
+  add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "posts", "users"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
- 投稿詳細ページにコメント投稿フォームを追加
- コメントは投稿とユーザーに紐づけて保存
- コメント投稿者のニックネームと投稿日時を表示（古い順で並べる）
- コメント投稿フォームに「コメントする」のプレースホルダーを表示
- コメントが空のまま送信された場合、投稿に失敗した旨を表示
- コメント表示部分をカードスタイルでレイアウト（max-width: 600px）
- 投稿者名をクリックするとマイページに遷移できるようにリンク設定

# Why
- 投稿に対するフィードバックや交流の場を提供するため
- 学習のモチベーションを他ユーザーのコメントで高め合うため
- ユーザー間のつながりを促進し、継続的な利用につなげるため
