### PR TITLE
コメント削除機能

### DIFF
--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -62,7 +62,7 @@
 
 .menu-items {
   display: none;
-  flex-direction: column; /* 縦並びにする */
+  flex-direction: column;
   gap: 6px;
   position: absolute;
   right: 0;
@@ -85,8 +85,8 @@
   border-radius: 6px;
   text-decoration: none;
   text-align: center;
-  white-space: nowrap;     /* ←これが改行防止の主役！ */
-  min-width: 60px;         /* ←細すぎるボタンにならないよう幅確保 */
+  white-space: nowrap;
+  min-width: 60px;
 }
 
 .menu-button:hover {
@@ -194,7 +194,7 @@
 
 .comment-submit-button {
   display: block;
-  margin: 4px auto 0;  /* 上の余白をギリギリに調整 */
+  margin: 4px auto 0;
   background-color: #00b3a6;
   color: #fff;
   border: none;
@@ -222,11 +222,13 @@
 
 /* 各コメントカード */
 .comment-card {
-  background-color: #fff;
-  border: 1px solid #eee;
+  position: relative; /* ↓日付の位置指定のために必要 */
+  max-width: 600px;
+  background-color: #f9f9f9;
+  padding: 14px 18px;
   border-radius: 10px;
-  padding: 16px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+  margin-bottom: 14px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 /* コメントメタ情報（名前と日付） */
@@ -239,8 +241,11 @@
 }
 
 .comment-date {
-  color: #aaa;
+  position: absolute;
+  bottom: 10px;
+  right: 18px;
   font-size: 12px;
+  color: #999;
 }
 
 
@@ -267,4 +272,24 @@
   margin-bottom: 15px;
   font-weight: bold;
   text-align: center;
+}
+
+/* コメント削除ボタン */
+.comment-delete-button {
+  background-color: #f08080;
+  color: white !important;
+  border: none;
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 12px;
+  cursor: pointer;
+  margin-left: 10px;
+  text-decoration: none;
+  transition: background-color 0.2s;
+}
+
+/* ホバー時も白文字のままに */
+.comment-delete-button:hover {
+  background-color: #e06666;
+  color: white !important;
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
+  before_action :authenticate_user!, only: [:create, :destroy]
 
   def create
     @comment = Comment.new(comment_params)
@@ -11,6 +11,16 @@ class CommentsController < ApplicationController
     else
       flash.now[:alert] = "コメントの投稿に失敗しました"
       render "posts/show", status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    comment = Comment.find(params[:id])
+    if comment.user == current_user
+      comment.destroy
+      redirect_to post_path(params[:post_id])
+    else
+      redirect_to post_path(params[:post_id])
     end
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,5 +4,4 @@ import "controllers"
 import "stopwatch"
 import "delete_confirm"
 import "chart.js";
-import "user_chart"; // ← グローバルに Chart が定義されるので import Chart は不要！
-
+import "user_chart";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
+
   </head>
 
   <body>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -78,10 +78,18 @@
       <div class="comment-card">
         <p class="comment-meta">
           <%= link_to comment.user.nickname, user_path(comment.user), class: "comment-author" %>
-          <span class="comment-date"><%= l(comment.created_at, format: :short) %></span>
+          <% if current_user == comment.user %>
+            <%= link_to "削除", post_comment_path(@post, comment), data: { turbo_method: :delete, turbo_confirm: "削除してもよろしいですか？" }, class: "comment-delete-button" %>
+          <% end %>
         </p>
-        <p class="comment-text"><%= simple_format(h(comment.text)) %></p>
+
+        <p class="comment-text"><%= comment.text %></p>
+
+        <p class="comment-date">
+          <%= l(comment.created_at, format: :short) %>
+        </p>
       </div>
+
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       get  :stopwatch
       post :save_time
     end
-    resources :comments, only: [:create]
+    resources :comments, only: [:create, :destroy]
   end
   resources :users, only: [:show]
 end


### PR DESCRIPTION
# What
- コメント削除機能を実装
- ログインユーザーが自身のコメントにのみ「削除」ボタンを表示
- Turboを利用し、削除時に確認ダイアログ（`turbo_confirm`）を表示
- コメント削除後は投稿詳細ページにリダイレクトされるよう設定
- 削除ボタンの見た目をCSSで調整

# Why
- コメントを投稿後、ユーザーが内容を取り消したくなるケースに対応するため
- ユーザー自身のコメントのみ削除できるようにすることで、セキュリティと整合性を保つため
- Turbo環境下でも削除処理が正しく動作するようにするため